### PR TITLE
18 Clean up work space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,10 +63,10 @@ jobs:
         id: removedockerimage
         run: |
           docker rmi nes_dep_build_${{ matrix.osversion }}
-      - name: Clean build artifacts
-        id: cleanbuildartifacts
+      - name: Clean workspace
+        id: cleanworkspace
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
 
   build-arm64-linux:
     timeout-minutes: 360
@@ -113,10 +113,10 @@ jobs:
         with:
           name: vcpkg-logs-${{ env.VCPKG_DEP_LIST }}
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
-      - name: Clean build artifacts
-        id: cleanbuildartifacts
+      - name: Clean workspace
+        id: cleanworkspace
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
 
   build-arm-osx:
     timeout-minutes: 360
@@ -163,10 +163,10 @@ jobs:
         with:
           name: vcpkg-logs-${{ env.VCPKG_DEP_LIST }}
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
-      - name: Clean build artifacts
-        id: cleanbuildartifacts
+      - name: Clean workspace
+        id: cleanworkspace
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z  
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
 
   build-x64-osx:
     timeout-minutes: 360
@@ -213,10 +213,10 @@ jobs:
         with:
           name: vcpkg-logs-${{ env.VCPKG_DEP_LIST }}
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
-      - name: Clean build artifacts
-        id: cleanbuildartifacts
+      - name: Clean workspace
+        id: cleanworkspace
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
 
   build-x64-linux-musl:
     timeout-minutes: 360
@@ -275,7 +275,7 @@ jobs:
         id: removedockerimage
         run: |
           docker rmi nes_dep_build_${{ matrix.osversion }}
-      - name: Clean build artifacts
-        id: cleanbuildartifacts
+      - name: Clean workspace
+        id: cleanworkspace
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,13 @@ jobs:
       - name: Set output vars to the actual tag name
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - name: Remove stale docker image
+        id: removestaledockerimage
+        if: always()
+        run: |
+          test -n "$(docker image ls -q nes_dep_build_${{ matrix.osversion }})" && \
+          docker image rm $(docker image ls -q nes_dep_build_${{ matrix.osversion }}) || \
+          true
       - name: Build Docker
         id: builddocker
         working-directory: ${{ github.workspace }}/docker/
@@ -59,11 +66,6 @@ jobs:
         with:
           name: vcpkg-logs-${{ env.VCPKG_DEP_LIST }}
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
-      - name: Remove docker image
-        id: removedockerimage
-        if: always()
-        run: |
-          docker rmi nes_dep_build_${{ matrix.osversion }}
       - name: Clean build artifacts
         id: cleanbuildartifacts
         if: always()
@@ -239,6 +241,13 @@ jobs:
       - name: Set output vars to the actual tag name
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - name: Remove stale docker image
+        id: removestaledockerimage
+        if: always()
+        run: |
+          test -n "$(docker image ls -q nes_dep_build_${{ matrix.osversion }})" && \
+          docker image rm $(docker image ls -q nes_dep_build_${{ matrix.osversion }}) || \
+          true
       - name: Build Docker
         id: builddocker
         working-directory: ${{ github.workspace }}/docker/
@@ -276,11 +285,6 @@ jobs:
         with:
           name: vcpkg-logs-${{ env.VCPKG_DEP_LIST }}
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
-      - name: Remove docker image
-        id: removedockerimage
-        if: always()
-        run: |
-          docker rmi nes_dep_build_${{ matrix.osversion }}
       - name: Clean build artifacts
         id: cleanbuildartifacts
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,8 @@ jobs:
         id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z \
+          ${{ github.workspace }}/vcpkg/{buildtrees,downloads,packages}
       - name: Remove docker image
         id: removedockerimage
         if: always()
@@ -121,7 +122,8 @@ jobs:
         id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z \
+          ${{ github.workspace }}/vcpkg/{buildtrees,downloads,packages}
 
   build-arm-osx:
     timeout-minutes: 360
@@ -172,7 +174,8 @@ jobs:
         id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z  
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z \
+          ${{ github.workspace }}/vcpkg/{buildtrees,downloads,packages}
 
   build-x64-osx:
     timeout-minutes: 360
@@ -223,7 +226,8 @@ jobs:
         id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z \
+          ${{ github.workspace }}/vcpkg/{buildtrees,downloads,packages}
 
   build-x64-linux-musl:
     timeout-minutes: 360
@@ -282,7 +286,8 @@ jobs:
         id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z \
+          ${{ github.workspace }}/vcpkg/{buildtrees,downloads,packages}
       - name: Remove docker image
         id: removedockerimage
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,8 @@ jobs:
         id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z \
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes \
+          nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-${{ matrix.osversion }}-nes.7z \
           ${{ github.workspace }}/vcpkg/{buildtrees,downloads,packages}
       - name: Remove docker image
         id: removedockerimage
@@ -122,7 +123,8 @@ jobs:
         id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z \
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes \
+          nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-${{ matrix.osversion }}-nes.7z \
           ${{ github.workspace }}/vcpkg/{buildtrees,downloads,packages}
 
   build-arm-osx:
@@ -174,7 +176,8 @@ jobs:
         id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z \
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes \
+          nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-${{ matrix.osversion }}-nes.7z \
           ${{ github.workspace }}/vcpkg/{buildtrees,downloads,packages}
 
   build-x64-osx:
@@ -226,7 +229,8 @@ jobs:
         id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z \
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes \
+          nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-${{ matrix.osversion }}-nes.7z \
           ${{ github.workspace }}/vcpkg/{buildtrees,downloads,packages}
 
   build-x64-linux-musl:
@@ -286,7 +290,8 @@ jobs:
         id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z \
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes \
+          nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-${{ matrix.osversion }}-nes.7z \
           ${{ github.workspace }}/vcpkg/{buildtrees,downloads,packages}
       - name: Remove docker image
         id: removedockerimage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,11 +64,11 @@ jobs:
         if: always()
         run: |
           docker rmi nes_dep_build_${{ matrix.osversion }}
-      - name: Clean workspace
-        id: cleanworkspace
+      - name: Clean build artifacts
+        id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
 
   build-arm64-linux:
     timeout-minutes: 360
@@ -115,11 +115,11 @@ jobs:
         with:
           name: vcpkg-logs-${{ env.VCPKG_DEP_LIST }}
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
-      - name: Clean workspace
-        id: cleanworkspace
+      - name: Clean build artifacts
+        id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
 
   build-arm-osx:
     timeout-minutes: 360
@@ -166,11 +166,11 @@ jobs:
         with:
           name: vcpkg-logs-${{ env.VCPKG_DEP_LIST }}
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
-      - name: Clean workspace
-        id: cleanworkspace
+      - name: Clean build artifacts
+        id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z  
 
   build-x64-osx:
     timeout-minutes: 360
@@ -217,11 +217,11 @@ jobs:
         with:
           name: vcpkg-logs-${{ env.VCPKG_DEP_LIST }}
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
-      - name: Clean workspace
-        id: cleanworkspace
+      - name: Clean build artifacts
+        id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
 
   build-x64-linux-musl:
     timeout-minutes: 360
@@ -281,8 +281,8 @@ jobs:
         if: always()
         run: |
           docker rmi nes_dep_build_${{ matrix.osversion }}
-      - name: Clean workspace
-        id: cleanworkspace
+      - name: Clean build artifacts
+        id: cleanbuildartifacts
         if: always()
         run: |
-          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
+          rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Install vcpkg
         id: bootstrapvcpkg
         run: |
-          docker run -v ${{ github.workspace }}:/build_dir nes_dep_build_${{ matrix.osversion }} ./build_dir/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+          docker run -v ${{ github.workspace }}:/build_dir --rm nes_dep_build_${{ matrix.osversion }} ./build_dir/vcpkg/bootstrap-vcpkg.sh -disableMetrics
         shell: bash
       - name: Install dependencies in manifest mode
         id: installdeps
         run: |
-          docker run -v ${{ github.workspace }}:/build_dir nes_dep_build_${{ matrix.osversion }} \
+          docker run -v ${{ github.workspace }}:/build_dir --rm nes_dep_build_${{ matrix.osversion }} \
           ./build_dir/vcpkg/vcpkg install --triplet=${{ env.VCPKG_DEP_LIST }}-nes \
           --host-triplet=${{ env.VCPKG_DEP_LIST }}-nes --overlay-triplets=/build_dir/custom-triplets/ --x-manifest-root=/build_dir/ --overlay-ports=/build_dir/vcpkg-registry/ports
       - name: Compress artifacts
@@ -237,12 +237,12 @@ jobs:
       - name: Install vcpkg
         id: bootstrapvcpkg
         run: |
-          docker run -v ${{ github.workspace }}:/build_dir nes_dep_build_${{ matrix.osversion }} ./build_dir/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+          docker run -v ${{ github.workspace }}:/build_dir --rm nes_dep_build_${{ matrix.osversion }} ./build_dir/vcpkg/bootstrap-vcpkg.sh -disableMetrics
         shell: bash
       - name: Install dependencies in manifest mode
         id: installdeps
         run: |
-          docker run -v ${{ github.workspace }}:/build_dir --env VCPKG_FORCE_SYSTEM_BINARIES=1 nes_dep_build_${{ matrix.osversion }} \
+          docker run -v ${{ github.workspace }}:/build_dir --env VCPKG_FORCE_SYSTEM_BINARIES=1 --rm nes_dep_build_${{ matrix.osversion }} \
           ./build_dir/vcpkg/vcpkg install --triplet=${{ env.VCPKG_DEP_LIST }}-nes \
           --host-triplet=${{ env.VCPKG_DEP_LIST }}-nes --overlay-triplets=/build_dir/custom-triplets/ --x-manifest-root=/build_dir/ --overlay-ports=/build_dir/vcpkg-registry/ports
       - name: Compress artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,10 @@ jobs:
         with:
           name: vcpkg-logs-${{ env.VCPKG_DEP_LIST }}
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
+      - name: Remove docker image
+        id: removedockerimage
+        run: |
+          docker rmi nes_dep_build_${{ matrix.osversion }}
       - name: Clean build artifacts
         id: cleanbuildartifacts
         run: |
@@ -267,6 +271,10 @@ jobs:
         with:
           name: vcpkg-logs-${{ env.VCPKG_DEP_LIST }}
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
+      - name: Remove docker image
+        id: removedockerimage
+        run: |
+          docker rmi nes_dep_build_${{ matrix.osversion }}
       - name: Clean build artifacts
         id: cleanbuildartifacts
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,6 @@ jobs:
       - name: Set output vars to the actual tag name
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-      - name: Remove stale docker image
-        id: removestaledockerimage
-        if: always()
-        run: |
-          test -n "$(docker image ls -q nes_dep_build_${{ matrix.osversion }})" && \
-          docker image rm $(docker image ls -q nes_dep_build_${{ matrix.osversion }}) || \
-          true
       - name: Build Docker
         id: builddocker
         working-directory: ${{ github.workspace }}/docker/
@@ -71,6 +64,13 @@ jobs:
         if: always()
         run: |
           rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
+      - name: Remove docker image
+        id: removedockerimage
+        if: always()
+        run: |
+          test -n "$(docker image ls -q nes_dep_build_${{ matrix.osversion }})" && \
+          docker image rm $(docker image ls -q nes_dep_build_${{ matrix.osversion }}) || \
+          true
 
   build-arm64-linux:
     timeout-minutes: 360
@@ -241,13 +241,6 @@ jobs:
       - name: Set output vars to the actual tag name
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-      - name: Remove stale docker image
-        id: removestaledockerimage
-        if: always()
-        run: |
-          test -n "$(docker image ls -q nes_dep_build_${{ matrix.osversion }})" && \
-          docker image rm $(docker image ls -q nes_dep_build_${{ matrix.osversion }}) || \
-          true
       - name: Build Docker
         id: builddocker
         working-directory: ${{ github.workspace }}/docker/
@@ -290,3 +283,10 @@ jobs:
         if: always()
         run: |
           rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z
+      - name: Remove docker image
+        id: removedockerimage
+        if: always()
+        run: |
+          test -n "$(docker image ls -q nes_dep_build_${{ matrix.osversion }})" && \
+          docker image rm $(docker image ls -q nes_dep_build_${{ matrix.osversion }}) || \
+          true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,10 +61,12 @@ jobs:
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
       - name: Remove docker image
         id: removedockerimage
+        if: always()
         run: |
           docker rmi nes_dep_build_${{ matrix.osversion }}
       - name: Clean workspace
         id: cleanworkspace
+        if: always()
         run: |
           rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
 
@@ -115,6 +117,7 @@ jobs:
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
       - name: Clean workspace
         id: cleanworkspace
+        if: always()
         run: |
           rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
 
@@ -165,6 +168,7 @@ jobs:
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
       - name: Clean workspace
         id: cleanworkspace
+        if: always()
         run: |
           rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
 
@@ -215,6 +219,7 @@ jobs:
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
       - name: Clean workspace
         id: cleanworkspace
+        if: always()
         run: |
           rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}
 
@@ -273,9 +278,11 @@ jobs:
           path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
       - name: Remove docker image
         id: removedockerimage
+        if: always()
         run: |
           docker rmi nes_dep_build_${{ matrix.osversion }}
       - name: Clean workspace
         id: cleanworkspace
+        if: always()
         run: |
           rm -rf nes-dependencies-${{ steps.vars.outputs.tag }}-${{ env.VCPKG_DEP_LIST }}-nes.7z ${{ github.workspace }}


### PR DESCRIPTION
This PR fixes the functionality to clean up build artifacts and also removes the generated NebulaStream Docker build images. Fixes #18.

## Change log

- Fixes deletion of the created dependency folder and 7z file.
- Removes the folders buildtrees, downloads, and packages, which are generated by vcpkg during the build process.
- Removes docker containers after they have completed.
- Removes all instances of the Docker image for a particular OS and architecture build.

## Notes

- The PR does not remove the checked-out repository itself. Doing so causes the step Post Run actions/checkout@v2 to fail.