### PR TITLE
Add nlohmann::json dependency to NES

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -56,6 +56,7 @@
       "platform": "arm64"
     },
     "oatpp",
-    "cpr"
+    "cpr",
+    "nlohmann-json"
   ]
 }


### PR DESCRIPTION
As part of moving away from cpprestsdk (in maintenance mode) we need to find a new json library.
Nlohmann-json suits our needs welll and can be easily plugged in. There already exists a dependecy verion (vnlohmann-json) that passes all tests.
